### PR TITLE
#14 & #15 Implement serverside logic to fetch screenings with max amount shown

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,8 +4,6 @@ import renderPage from './lib/renderPage.js'
 import { filmExists } from './services/fetchMovies.js'
 import { renderErrorPage } from './lib/errorHandler.js'
 import apiRoutes from './routes/apiRoutes.js'
-import { getScreeningsForNextFiveDays } from './services/screeningsService.js'
-import screeningAdapter from './services/fetchScreenings.js'
 
 export default function initApp(api) {
   const app = express()
@@ -16,8 +14,7 @@ export default function initApp(api) {
 
   app.get('/', async (request, response, next) => {
     try {
-      const screenings = await getScreeningsForNextFiveDays(screeningAdapter)
-      await renderPage(response, 'hem', { screenings })
+      await renderPage(response, 'hem')
     } catch (err) {
       next(err)
     }
@@ -81,7 +78,7 @@ export default function initApp(api) {
 
   app.use('/api', apiRoutes(api))
   app.use('/static', express.static('./static'))
-  app.use('/static/Script', express.static('./static/Script'))
+  // app.use('/static/Script', express.static('./static/Script'))
 
   // Testfel route för 500
   app.get('/test-error', (request, response, next) => {

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,8 @@ import renderPage from './lib/renderPage.js'
 import { filmExists } from './services/fetchMovies.js'
 import { renderErrorPage } from './lib/errorHandler.js'
 import apiRoutes from './routes/apiRoutes.js'
+import { getScreeningsForNextFiveDays } from './services/screeningsService.js'
+import screeningAdapter from './services/fetchScreenings.js'
 
 export default function initApp(api) {
   const app = express()
@@ -14,7 +16,8 @@ export default function initApp(api) {
 
   app.get('/', async (request, response, next) => {
     try {
-      await renderPage(response, 'hem')
+      const screenings = await getScreeningsForNextFiveDays(screeningAdapter)
+      await renderPage(response, 'hem', { screenings })
     } catch (err) {
       next(err)
     }
@@ -78,6 +81,7 @@ export default function initApp(api) {
 
   app.use('/api', apiRoutes(api))
   app.use('/static', express.static('./static'))
+  app.use('/static/Script', express.static('./static/Script'))
 
   // Testfel route för 500
   app.get('/test-error', (request, response, next) => {

--- a/src/app.js
+++ b/src/app.js
@@ -78,7 +78,7 @@ export default function initApp(api) {
 
   app.use('/api', apiRoutes(api))
   app.use('/static', express.static('./static'))
-  // app.use('/static/Script', express.static('./static/Script'))
+  app.use('/static/Script', express.static('./static/Script'))
 
   // Testfel route för 500
   app.get('/test-error', (request, response, next) => {

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -1,6 +1,8 @@
 import express from 'express'
 import { getTopRatedMoviesByRating } from '../services/moviesTopRated.js'
 import cmsAdapter from '../services/fetchReviews.js'
+import { getScreeningsForNextFiveDays } from '../services/screeningsService.js'
+import screeningAdapter from '../services/fetchScreenings.js'
 
 const router = express.Router()
 

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -14,5 +14,24 @@ export default function apiRoutes(api) {
     }
   })
 
+  /*
+  router.get('/movies/screenings', async (request, response, next) => {
+    try {
+      const screenings = await getScreeningsForMovies(screeningAdapter, [])
+      response.json(screenings)
+    } catch (err) {
+      next(err)
+    }
+  })
+*/
+  router.get('/movies/screenings/next-five-days', async (request, response, next) => {
+    try {
+      const screenings = await getScreeningsForNextFiveDays(screeningAdapter)
+      response.json(screenings)
+    } catch (err) {
+      next(err)
+    }
+  })
+
   return router
 }

--- a/src/services/fetchScreenings.js
+++ b/src/services/fetchScreenings.js
@@ -1,0 +1,50 @@
+import fetch from 'node-fetch'
+import { getScreeningsForNextFiveDays } from './screeningsService.js'
+
+function toScreeningObject(apiObjekt) {
+  return {
+    id: apiObjekt.id,
+    ...apiObjekt.attributes,
+    movie: apiObjekt.attributes.movie.data
+      ? {
+          id: apiObjekt.attributes.movie.data.id,
+          ...apiObjekt.attributes.movie.data.attributes,
+        }
+      : null,
+  }
+}
+
+const screeningAdapter = {
+  loadScreeningsForDate: async (formattedDate) => {
+    const res = await fetch(
+      `https://plankton-app-xhkom.ondigitalocean.app/api/screenings?populate=movie&filters[start_time][$gte]=${formattedDate}T00:00:00.000Z&filters[start_time][$lt]=${formattedDate}T23:59:59.999Z`
+    )
+    const payload = await res.json()
+    return {
+      data: payload.data.map(toScreeningObject),
+      meta: payload.meta,
+    }
+  },
+
+  loadScreeningsForMovie: async (movieId) => {
+    const res = await fetch(
+      `https://plankton-app-xhkom.ondigitalocean.app/api/screenings?populate=movie&filters[movie]=${movieId}`
+    )
+    const payload = await res.json()
+    console.log('API-Response:', movieId, payload)
+    return {
+      data: payload.data.map(toScreeningObject),
+      meta: payload.meta,
+    }
+  },
+  loadAllScreenings: async () => {
+    const res = await fetch(`https://plankton-app-xhkom.ondigitalocean.app/api/screenings?populate=movie`)
+    const payload = await res.json()
+    return {
+      data: payload.data.map(toScreeningObject),
+      meta: payload.meta,
+    }
+  },
+}
+
+export default screeningAdapter

--- a/src/services/screeningsService.js
+++ b/src/services/screeningsService.js
@@ -1,0 +1,28 @@
+import screeningAdapter from './fetchScreenings.js'
+
+export async function getScreeningsForMovies(screeningAdapter, movieIds = []) {
+  let screenings = []
+
+  if (movieIds.length === 0) {
+    const response = await screeningAdapter.loadAllScreenings()
+    return response.data
+  } else {
+    const fetchPromises = movieIds.map((movieId) => screeningAdapter.loadScreeningsForMovie(movieId))
+    const response = await Promise.all(fetchPromises)
+    screenings = response.flatMap((response) => response.data)
+  }
+}
+
+export async function getScreeningsForNextFiveDays(screeningAdapter) {
+  const screenings = []
+  const now = new Date()
+  for (let i = 0; i < 5; i++) {
+    const date = new Date(now)
+    date.setDate(now.getDate() + i)
+    const formattedDate = date.toISOString().split('T')[0]
+    const response = await screeningAdapter.loadScreeningsForDate(formattedDate)
+    screenings.push(...response.data)
+  }
+
+  return screenings
+}

--- a/static/Script/fetchScreenings.js
+++ b/static/Script/fetchScreenings.js
@@ -1,0 +1,26 @@
+fetch('/api/movies/screenings/next-five-days')
+  .then((response) => {
+    if (!response.ok) {
+      throw new Error('Network response was not ok')
+    }
+    return response.json()
+  })
+  .then((screenings) => {
+    console.log('Received screenings for next five days:', screenings)
+    if (screenings.length === 0) {
+      document.querySelector('.screening-list').innerHTML = '<li>No screenings found</li>'
+    } else {
+      const limitedScreenings = screenings.slice(0, 10)
+      document.querySelector('.screenings-list').innerHTML = limitedScreenings
+        .map((screening) => {
+          return `<li>
+          ${screening.movie.title} - 
+          Date: ${new Date(screening.start_time).toLocaleDateString()}, 
+          Time: ${new Date(screening.start_time).toLocaleTimeString()}, 
+          Room: ${screening.room || 'N/A'}
+        </li>`
+        })
+        .join('')
+    }
+  })
+  .catch((error) => console.error('Error fetching screenings:', error))

--- a/static/Script/fetchScreenings.js
+++ b/static/Script/fetchScreenings.js
@@ -8,7 +8,7 @@ fetch('/api/movies/screenings/next-five-days')
   .then((screenings) => {
     console.log('Received screenings for next five days:', screenings)
     if (screenings.length === 0) {
-      document.querySelector('.screening-list').innerHTML = '<li>No screenings found</li>'
+      document.querySelector('.screenings-list').innerHTML = '<li>No screenings found</li>'
     } else {
       const limitedScreenings = screenings.slice(0, 10)
       document.querySelector('.screenings-list').innerHTML = limitedScreenings

--- a/templates/hem.ejs
+++ b/templates/hem.ejs
@@ -3,3 +3,11 @@
     <h3 class="top-rated__title"><%= frontPageContent.hem.topRatedTitle %></h3>
     <ul class="top-rated__container"></ul>
 </div>
+
+<!-- Placeholder for testing, feel free to delete -->
+<script type="module" src="/static/script/fetchScreenings.js"></script>
+
+<div class="screenings">
+    <li class="screenings-list"></li>
+</div>
+<!--END-->


### PR DESCRIPTION
## Pull Request Type
Please check the type of change your PR introduces:
- [x] Feature (a new feature for the project)
- [ ] Fix (a bug fix)
- [ ] Chore (updating grunt tasks etc; no production code change)
- [ ] Refactor (refactoring production code)
- [ ] Docs (changes to the documentation)
- [ ] Style (formatting, missing semi colons, etc; no production code change)
- [ ] Test (adding missing tests, refactoring tests; no production code change)

## Description
This pull request combines two user stories into a single implementation:
- Issue #14 : An API endpoint was designed and implemented to fetch screenings for the next five days from the server database. This allows the front-end to showcase upcoming movie screenings for each movie.
- Issue #15 : Enhanced the said endpoint to limit the number of screenings displayed to a maximum of 10. 

## Motivation and Context
[Why is this change required? What problem does it solve?]

## How Has This Been Tested?
[Describe the tests that you ran to verify your changes]

## Screenshots (if appropriate):
[Add screenshots here]

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have named this PR according to following naming convention: #[issue-number] PR description

## Additional Information:
[Add any other information about the PR here]

## Related Issues:
- #14 
